### PR TITLE
Change to devTools-style <Selector />

### DIFF
--- a/packages/gui/components/App/index.tsx
+++ b/packages/gui/components/App/index.tsx
@@ -11,7 +11,6 @@ const client = createClient({
 
 export const App: FunctionComponent = () => {
   const iframe = useRef<HTMLIFrameElement>(null);
-  const [isEnabled, setIsEnabled] = useState(true);
   const [target, setTarget] = useState();
   const [isLoaded, setIsLoaded] = useState(false);
   const [root, setRoot] = useState();
@@ -32,37 +31,27 @@ export const App: FunctionComponent = () => {
     const handleKeyPress = (event: KeyboardEvent) => {
       const { key } = event;
 
-      if (key === "/" && !isEnabled) {
-        event.preventDefault();
-
-        return setIsEnabled(true);
-      }
-
-      if (key === "Escape") {
-        target ? setTarget(undefined) : setIsEnabled(false);
+      if (key === "Escape" && target) {
+        setTarget(undefined);
       }
     };
 
     window.addEventListener("keydown", handleKeyPress);
 
     return () => window.removeEventListener("keydown", handleKeyPress);
-  }, [isEnabled, target]);
+  }, [target]);
 
   return (
     <Provider value={client}>
-      {isEnabled ? (
-        <Panel>
-          {target ? (
-            <Inspector element={target} />
-          ) : root ? (
-            <Selector onSelect={setTarget} root={root} />
-          ) : (
-            <div className="m-4 bg-gray-700 p-4 text-center">
-              Loading&hellip;
-            </div>
-          )}
-        </Panel>
-      ) : null}
+      <Panel>
+        {target ? (
+          <Inspector element={target} />
+        ) : root ? (
+          <Selector onSelect={setTarget} root={root} />
+        ) : (
+          <div className="m-4 bg-gray-700 p-4 text-center">Loading&hellip;</div>
+        )}
+      </Panel>
 
       <iframe
         onLoad={() => setIsLoaded(true)}

--- a/packages/gui/components/Selector/index.tsx
+++ b/packages/gui/components/Selector/index.tsx
@@ -12,7 +12,13 @@ export const Selector: FunctionComponent<SelectorProps> = ({
   onSelect,
   root
 }) => {
-  const [rect, setRect] = useState();
+  const [rect, setRect] = useState({
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  });
+
   const [target, setTarget] = useState();
 
   useEffect(() => {
@@ -39,6 +45,10 @@ export const Selector: FunctionComponent<SelectorProps> = ({
     }
   }, [target]);
 
+  const { top, right, bottom, left } = rect;
+  const width = right - left;
+  const height = bottom - top;
+
   return (
     <>
       <section className="shadow-inner p-3 pr-0 overflow-auto">
@@ -51,20 +61,28 @@ export const Selector: FunctionComponent<SelectorProps> = ({
       </section>
 
       {rect &&
+        target &&
         createPortal(
           <div
-            className="fixed top-0 left-64 w-full h-full bg-gray-600 opacity-50 pointer-events-none text-black z-40"
+            className="fixed pointer-events-none z-40 border-blue-500 border border-dashed"
             style={{
-              clipPath: `polygon(0 0, 100% 0, 100% 100%, ${
-                rect.right
-              }px 100%, ${rect.right}px ${rect.top}px, ${rect.left}px ${
-                rect.top
-              }px, ${rect.left}px ${rect.bottom}px, ${rect.right}px ${
-                rect.bottom
-              }px, ${rect.right}px 100%, 0 100%)`,
-              transition: "all 200ms ease-out"
+              left: `calc(16rem + ${left}px)`,
+              height,
+              width,
+              top,
+              transition: "all 200ms ease-in-out"
             }}
-          />,
+          >
+            <label className="absolute text-white font-mono text-xs bg-blue-500 px-1 py-px -mt-5 -ml-px rounded-t truncate max-w-full">
+              {target.tagName.toLowerCase()}
+              <small className="text-blue-200">
+                {target.className
+                  ? `.${target.className.split(" ").join(".")}`
+                  : null}
+              </small>
+            </label>
+            <div className="w-full h-full bg-blue-100 opacity-50" />
+          </div>,
           document.body
         )}
     </>


### PR DESCRIPTION
- [x] Selector should use an outline instead of a grayed out screen.
- [x] Show component/element name above the selector (or in the bottom left, like Chrome network status?).
- [ ] Keep selector around element (but hide it when doing previews. Maybe fade in/out depending on if you're in the iframe?)
- [ ] Fix the `<Selector />` resizing issue on save/reload.